### PR TITLE
names on computers are only shown if an employee is attached to it

### DIFF
--- a/hrapp/templates/computers/list.html
+++ b/hrapp/templates/computers/list.html
@@ -13,9 +13,10 @@
         {%else%}
             <p>{{ computer.make }}</p>
         {%endif%}
-        <p>{{ computer.employee.first_name }} {{ computer.employee.last_name }}</p>
-    </li>
-        
+        {% if computer.employee.first_name is not None %}
+            <p>{{ computer.employee.first_name }} {{ computer.employee.last_name }}</p>
+        {% endif %}
+    </li>    
 {% endfor %}
 </div>
 


### PR DESCRIPTION
git fetch --all
git checkout MB-django-V5

check that when displaying the computer list, only names of employees assigned to a computer will show.
if a computer is not assigned to a user, no name should be displayed